### PR TITLE
Added pkgs number for distros that use apt

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -11,6 +11,18 @@ PURPLE='\033[1;35m'
 CYAN='\033[1;36m'
 WHITE='\033[1;37m'
 
+#store OS information to collect number of packages from different sources(apt or pacman)
+os=$(awk -F '"' '/PRETTY/ {print $2}' /etc/os-release)
+pkgs=""
+case $os in 
+*"Ubuntu"*|*"Mint"*|*"Debian"*|*"Pop!_OS")
+    pkgs=$(dpkg-query -l | grep "^ii" | wc -l)
+    ;;
+*"Arch"*)
+    pkgs=$(pacman -Q | wc -l)
+    ;;
+esac
+
 # output errors to null
 exec 2>/dev/null
 
@@ -26,7 +38,7 @@ echo -ne "${CYAN}uptime${NC} ~ " ; uptime --pretty | sed -e 's/up//'
 echo -ne "${BLUE}shell${NC} ~ " ; echo $SHELL | sed 's%.*/%%'
 
 # PRETTY_NAME from /etc/os-release
-echo -ne "${PURPLE}os${NC} ~ " ; awk -F '"' '/PRETTY/ {print $2}' /etc/os-release
+echo -ne "${PURPLE}os${NC} ~ " ; echo "$os"
 
 # desktop enviornment from xsessions
 echo -ne "${RED}de/wm${NC} ~ " ; awk '/^DesktopNames/' /usr/share/xsessions/* | sed 's/DesktopNames=//g'
@@ -38,8 +50,7 @@ echo -ne "${YELLOW}gtk${NC} ~ " ; grep 'gtk-theme-name' ~/.config/gtk-3.0/* | se
 echo -ne "${GREEN}cpu${NC} ~ " ; grep -m 1 "model name" /proc/cpuinfo | sed 's/^[model name:.* \t]*//'
 
 # installed packages from package manager
-echo -ne "${CYAN}pkgs${NC} ~ " ; pacman -Q | wc -l
-
+echo -ne "${CYAN}pkgs${NC} ~ " ; echo "$pkgs"
 # MemTotal in /proc/meminfo
 echo -ne "${BLUE}ram${NC} ~ " ; awk '/MemTotal:/ {printf "%d MiB\n", $2 / 1024}' /proc/meminfo 
 

--- a/fetch.sh
+++ b/fetch.sh
@@ -15,7 +15,7 @@ WHITE='\033[1;37m'
 os=$(awk -F '"' '/PRETTY/ {print $2}' /etc/os-release)
 pkgs=""
 case $os in 
-*"Ubuntu"*|*"Mint"*|*"Debian"*|*"Pop!_OS")
+*"Ubuntu"*|*"Mint"*|*"Debian"*|*"Pop!_OS"*)
     pkgs=$(dpkg-query -l | grep "^ii" | wc -l)
     ;;
 *"Arch"*)


### PR DESCRIPTION
By storing OS name in a variable, we can use it to get the number of packages from the package manager corresponding to the chosen OS: 
```
os=$(awk -F '"' '/PRETTY/ {print $2}' /etc/os-release)
pkgs=""
case $os in 
*"Ubuntu"*|*"Mint"*|*"Debian"*|*"Pop!_OS")
    pkgs=$(dpkg-query -l | grep "^ii" | wc -l)
    ;;
*"Arch"*)
    pkgs=$(pacman -Q | wc -l)
    ;;
esac
```
We can easily do this for other package managers by adding more cases.