### PR TITLE
Fixed reading of uptime on busybox based systems.

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -25,7 +25,16 @@ uname -r
 
 # // UPTIME // run 'uptime'
 echo -ne "${CYAN}uptime${NC} ~ "
-uptime --pretty | sed -e 's/up//;s/^ *//'
+# Check architecture - busybox version doesn't support pretty flag
+if [ `readlink -f /usr/bin/uptime` != "/bin/busybox" ] ; then
+   uptime --pretty | sed -e 's/up//;s/^ *//'
+else
+   UPTIME=$(uptime)
+   UPTIME=$(echo -n "$UPTIME" | sed -e 's/^.*up //')
+   UPTIME=$(echo "$UPTIME" | sed -e 's/load.*$//')
+   UPTIME=${UPTIME%\,*}
+   echo "$UPTIME"
+fi
 
 
 # // OS // ARCH // print 'PRETTY_NAME' / get processor speed


### PR DESCRIPTION
Busybox version of uptime does not support pretty
flag, uptime has to be read raw and parsed manually.

This resolves issue #12 in the tracker.

 On branch pretty
 Changes to be committed:
	modified:   fetch.sh