### PR TITLE
Terminal determination: return unknown if pstree not present

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -141,7 +141,11 @@ fi
 
 # // TERM // get terminal name w/ pstree
 shell="$(echo $SHELL | sed 's%.*/%%')"
-term="$(pstree -sA $$)"; term="$(echo ${term%---${shell}*})"; term="$(echo ${term##*---})"
+if [ `command -v pstree` ] ; then
+	term="$(pstree -sA $$)"; term="$(echo ${term%---${shell}*})"; term="$(echo ${term##*---})"
+else
+	term="unknown"
+fi
 
 echo -ne "${GREEN}term${NC} ~ "
 echo $term | tr -d "\n"


### PR DESCRIPTION
Output cleanup suggestion for the term issue when pstree is not present. This option just returns an unknown if pstree isn't present. So far I haven't seen an alternative option that does work under busybox - everything either needs pstree or the full version of ps that supports all the other flags (ps in busybox supports no flags at all).

Thanks!