### PR TITLE
Added Implementation for Load Averages:

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -94,7 +94,7 @@ else
 fi
 
 # // LOAD AVGS // w tr /proc/loadavg
-echo -ne "${YELLOW}avgs:${NC} ~ "
+echo -ne "${YELLOW}avgs${NC} ~ "
 LOADAVG=( $(tr ' ' '\n' < /proc/loadavg) )
 echo -ne "${LOADAVG[0]} "
 echo -ne "${LOADAVG[1]} "

--- a/fetch.sh
+++ b/fetch.sh
@@ -93,12 +93,18 @@ else
 	echo -e '\n'
 fi
 
+# // LOAD AVGS // w tr /proc/loadavg
+echo -ne "${YELLOW}avgs:${NC} ~ "
+LOADAVG=( $(tr ' ' '\n' < /proc/loadavg) )
+echo -ne "${LOADAVG[0]} "
+echo -ne "${LOADAVG[1]} "
+echo -e "${LOADAVG[2]}"
 
 # // GPU // with lscpi
 if [[ $(command -v lspci) ]] ; then
 	echo -ne "${PURPLE}gpu${NC} ~ "
 	lspci | grep -i --color 'vga\|3d\|2d' | sed 's/VGA compatible controller//;s/Advanced Micro Devices, Inc//;s/NVIDIA Corporation//;s/Corporation//;s/Controller//;s/Family//;s/Processor//;s/Mixture//;s/Model//;s/Generation/Gen/g' | tr -d '.:[]' | sed 's/^.....//;s/^ *//'
-else 
+else
 	echo -e '\n'
 fi
 


### PR DESCRIPTION
An early implementation of Load Averages for Fetch.sh

This is a simple redirection of the /proc/loadavg file which stores this information, and breaks it into an array which is then output via Echos. Since each load average is a separate member of the array, they can be arranged tastefully and easily should anyone wish to move their location in the code.

closes #21 