### PR TITLE
Loadavg: changed tr method to using awk

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -94,11 +94,8 @@ else
 fi
 
 # // LOAD AVGS // w tr /proc/loadavg
-#echo -ne "${YELLOW}avgs${NC} ~ "
-#LOADAVG=( $(tr ' ' '\n' < /proc/loadavg) )
-#echo -ne "${LOADAVG[0]} "
-#echo -ne "${LOADAVG[1]} "
-#echo -e "${LOADAVG[2]}"
+echo -ne "${YELLOW}avgs${NC} ~ "
+cat /proc/loadavg | awk '{print $1,$2,$3}'
 
 # // GPU // with lscpi
 if [[ $(command -v lspci) ]] ; then


### PR DESCRIPTION
This is a follow-up to issue #22 after OpenWRT had issues with the tr method of separating the load averages out. Switched code to a simple one-line version using awk. Verified working on both Debian 11/x86, and three different OpenWRT machines on different hardware.