### PR TITLE
Trying alternative pkg show:

### DIFF
--- a/components/pkgs.sh
+++ b/components/pkgs.sh
@@ -16,11 +16,19 @@ elif test -e /var/log/packages ; then
 elif [[ $(command -v opkg) ]] ; then
         opkg list-installed | wc -w
 elif [[ $(command -v emerge) ]] ; then
-  ls -d /var/db/pkg/*/* | wc -l
-elif [[ $(command -v guix) ]] ; then
-        guix package --list-installed | wc -l
-elif [[ $(command -v nixos-rebuild) ]] ; then
-        ls /run/current-system/sw/bin/ | wc -l
+        ls -d /var/db/pkg/*/* | wc -l
 else
-        echo not found
+        echo "pkgs not found"
+fi
+
+# // GUIX PKGS // seperate count for GUIX packages:
+if [[ $(command -v guix) ]] ; then
+        echo -ne "${YELLOW}GUIX pkgs${NC} ~ "
+        guix package --list-installed | wc -l
+fi
+
+# // NIX PKGS // seperate count for NIX packages:
+if [[ $(command -v nixos-rebuild) ]] ; then
+        echo -ne "${PURPLE}NIX pkgs${NC} ~ "
+        ls /run/current-system/sw/bin/ | wc -l
 fi


### PR DESCRIPTION
This would be an alternative where we are able to Show GUIX and NIX packages installed as a separate value. This is solely due to the fact that GUIX and NIX can be installed in addition to a distributions normal package manager, and it's tallies would be separate from the default package manager. 

Likewise if a user doesn't have them installed, they simply don't show.