### PR TITLE
Display term even if shell is called within shell

### DIFF
--- a/components/cpu_gpu.sh
+++ b/components/cpu_gpu.sh
@@ -14,9 +14,9 @@ fi
 
 
 # get cpu frequency if /sys/devices/system/cpu exist
-max_cpu=$(head /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq | sed 's/......$/.&/;s/....$//' | tr -d '\n')
-scal_cpu=$(head /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq | sed 's/......$/.&/;s/.....$//' | tr -d '\n')
 if test -e /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq ; then
+        max_cpu=$(head /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq | sed 's/......$/.&/;s/....$//' | tr -d '\n')
+        scal_cpu=$(head /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq | sed 's/......$/.&/;s/.....$//' | tr -d '\n')
         echo -ne "${CYAN}$max_cpu${NC}"
         echo -ne "@${YELLOW}$scal_cpu${NC}" ; echo GHz
 else

--- a/components/term_shell.sh
+++ b/components/term_shell.sh
@@ -4,7 +4,7 @@
 # // TERM // get terminal name w/ pstree
 shell="$(echo $SHELL | sed 's%.*/%%')"
 if [ `command -v pstree` ] ; then
-        term="$(pstree -sA $$)"; term="$(echo ${term%---${shell}*})"; term="$(echo ${term##*---})"
+        term="$(pstree -sA $$)"; term="$(echo ${term%%---${shell}*})"; term="$(echo ${term##*---})"
 else
         term="unknown"
 fi


### PR DESCRIPTION
Regarding issue #15 , this should find the parent of the first bash shell invoked, not just the last one like it was before, resulting in outputting the wrong name in the parent tree. 