### PR TITLE
Get terminal name from the process name of grandparent PID

### DIFF
--- a/components/term_shell.sh
+++ b/components/term_shell.sh
@@ -3,9 +3,11 @@
 
 # // TERM // get terminal name w/ pstree
 shell="$(echo $SHELL | sed 's%.*/%%')"
-term="$(pstree -sA $$)"; term="$(echo ${term%%---${shell}*})"; term="$(echo ${term##*---})"
+pppid=$(ps -o ppid= -p $PPID  | awk '{print $1}')
+term=$(ps -o comm= -p "$pppid")
+
 if [[ $(command -v pstree) ]] ; then
-  echo -ne "${GREEN}term${NC} ~ " 
+  echo -ne "${GREEN}term${NC} ~ "
   echo $term | tr -d '\n'
 else
   echo $TERM


### PR DESCRIPTION
Fixes the regression introduced by 451e47b68faaa0515dfc25e0cef3cb254973005b. Fixes #15.

Known issues: Breaks when script is sourced. Grandparent PID will be the PPID of the terminal emulator. The script shouldn't be sourced anyway. Maybe sourcing should be [detected](https://stackoverflow.com/questions/2683279/how-to-detect-if-a-script-is-being-sourced) and abort the execution.