### PR TITLE
Fix theme indentation issue when no dm found

### DIFF
--- a/components/de-wm_theme.sh
+++ b/components/de-wm_theme.sh
@@ -9,7 +9,7 @@ elif [[ -e /usr/share/wayland-sessions/ ]] ; then
 elif [[ $(command -v xprop) ]] ; [[ ! -z $DISPLAY ]] ; then
         xprop -root | grep -m1 '^_NET_WM_NAME' | sed 's/^_NET_WM_NAME//g;s/(UTF8_STRING) = //g' | tr -d '"\n'
 else
-        echo not found
+        echo -n not found
 fi
 
 


### PR DESCRIPTION
This should fix the cosmetic issue mentioned in #18 that theme is on a new line and indented when no DE/WM is found.