### PR TITLE
Enable script to be called from any location

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -11,13 +11,15 @@ PURPLE='\033[1;35m'
 CYAN='\033[1;36m'
 WHITE='\033[1;37m'
 
-source ./components/host.sh
-source ./components/kernel.sh
-source ./components/uptime.sh
-source ./components/os_arch.sh
-source ./components/de-wm_theme.sh
-source ./components/cpu_gpu.sh
-#source ./components/load.sh
-source ./components/pkgs.sh
-source ./components/ram_swap.sh
-source ./components/term_shell.sh
+script_path=$(dirname "$(readlink -f "$0")")
+
+source "$script_path/components/host.sh"
+source "$script_path/components/kernel.sh"
+source "$script_path/components/uptime.sh"
+source "$script_path/components/os_arch.sh"
+source "$script_path/components/de-wm_theme.sh"
+source "$script_path/components/cpu_gpu.sh"
+#source "$script_path/components/load.sh"
+source "$script_path/components/pkgs.sh"
+source "$script_path/components/ram_swap.sh"
+source "$script_path/components/term_shell.sh"


### PR DESCRIPTION
Right now the script can only be executed in the directory where it's installed, because of the way the component scripts are sourced. Executing the script from anywhere else gives these errors:

```
fetch.sh/fetch.sh: line 14: ./components/host.sh: No such file or directory
fetch.sh/fetch.sh: line 15: ./components/kernel.sh: No such file or directory
fetch.sh/fetch.sh: line 16: ./components/uptime.sh: No such file or directory
fetch.sh/fetch.sh: line 17: ./components/os_arch.sh: No such file or directory
fetch.sh/fetch.sh: line 18: ./components/de-wm_theme.sh: No such file or directory
fetch.sh/fetch.sh: line 19: ./components/cpu_gpu.sh: No such file or directory
fetch.sh/fetch.sh: line 21: ./components/pkgs.sh: No such file or directory
fetch.sh/fetch.sh: line 22: ./components/ram_swap.sh: No such file or directory
fetch.sh/fetch.sh: line 23: ./components/term_shell.sh: No such file or directory
```

This PR fixes that, by prepending the correct path to each component script.