### PR TITLE
Add xbps package manager for Void Linux

### DIFF
--- a/components/pkgs.sh
+++ b/components/pkgs.sh
@@ -17,6 +17,8 @@ elif [[ $(command -v opkg) ]] ; then
         opkg list-installed | wc -w
 elif [[ $(command -v emerge) ]] ; then
         ls -d /var/db/pkg/*/* | wc -l
+elif [[ $(command -v xbps-query) ]]; then
+        xbps-query -l | grep -c '^ii'
 else
         echo "pkgs not found"
 fi


### PR DESCRIPTION
This PR adds xbps-query, a command of xbps package manager, which is used in Void Linux
Before 
![image](https://user-images.githubusercontent.com/29520244/143413148-050af8b3-cea5-4941-af79-3e151fb321c7.png)
After
![image](https://user-images.githubusercontent.com/29520244/143413197-9663fae3-a15b-4632-b4e5-763444df5c1e.png)
Notably, de-wm, gtk is not working on a base installation of Void Linux, as well as term (st-256color is correct, but the line above is a mess)