### PR TITLE
GPU name under WSL

### DIFF
--- a/components/cpu_gpu.sh
+++ b/components/cpu_gpu.sh
@@ -18,7 +18,10 @@ fi
 
 
 # // GPU // with lscpi
-if [[ $(command -v lspci) ]] ; then
+if [[ "$kernel" == *"microsoft-standard-WSL"* ]]; then
+        echo -ne "${GREEN}gpu${NC} ~ "
+        wmic.exe path win32_VideoController get name | awk 'NR==2'
+elif [[ $(command -v lspci) ]] ; then
         echo -ne "${GREEN}gpu${NC} ~ "
         lspci | grep -im1 --color 'vga\|3d\|2d' | sed 's/VGA compatible controller//;s/Advanced Micro Devices, Inc//;s/NVIDIA Corporation//;s/Corporation//;s/Controller//;s/controller//;s/storage//;s/filesystem//;s/0000//;s/Family//;s/Processor//;s/Mixture//;s/Model//;s/Generation/Gen/g' | tr -d '.:[]' | sed 's/^.....//;s/^ *//' 
 fi

--- a/fetch.sh
+++ b/fetch.sh
@@ -21,6 +21,7 @@ exec 2>/dev/null
 # host
 host=$(uname -n)
 user=$(echo $USER)
+kernel="$(uname -r)"
 
 # os_arch
 os=$(awk -F '"' '/PRETTY/ {print $2}' /etc/os-release)


### PR DESCRIPTION
Added a cmd command that makes us display the real GPU name properly. 
Please test this branch on non-WSL environments before merging.