### PR TITLE
RAM/Swap fixes for MacOS/Darwin: Alpha Branch:

### DIFF
--- a/components/ram_swap.sh
+++ b/components/ram_swap.sh
@@ -4,8 +4,9 @@
 echo -ne "${RED}ram${NC} ~ "
 if [[ "$sys" = "Darwin" ]] ; then
 	echo -n "$(top -l 1 -s 0 | grep PhysMem | awk '{print($2)}' | sed 's/.$//')"
-	echo -n "@"
+	echo -n "M "
 	hostinfo | awk 'FNR == 8 {print($4)}' | sed 's/...$//'
+	echo -n "G"
 elif [[ ! -z "$max_ram" ]] ; then
 	echo -n "$cur_ram$max_ram"
 else
@@ -15,8 +16,8 @@ fi
 
 # // SWAP // print 'Size' from /proc/swaps
 if [[ "$sys" = "Darwin" ]] ; then
-	echo -ne "${PURPLE}swap${NC} ~ "
-	sysctl vm.swapusage | awk -F: '{print($2)}' | sed 's/.(encrypted)$//'
+  echo -ne " ${PURPLE}swap${NC} ~ "
+  sysctl vm.swapusage | awk '{print($7)}'
 elif [[ "$swap_count" = "2" ]] ; then
 	let "swap1_mb = $swap1_kb / 1024"
 	echo -ne " \e \e \e \e ${PURPLE}swap${NC} ~ "
@@ -30,4 +31,3 @@ elif [[ "$swap_count" > "2" ]] ; then
 else
 	echo -ne "\n"
 fi
-    

--- a/components/ram_swap.sh
+++ b/components/ram_swap.sh
@@ -4,8 +4,8 @@
 echo -ne "${RED}ram${NC} ~ "
 if [[ "$sys" = "Darwin" ]] ; then
 	echo -n "$(top -l 1 -s 0 | grep PhysMem | awk '{print($2)}' | sed 's/.$//')"
-	echo -n "M "
-	hostinfo | awk 'FNR == 8 {print($4)}' | sed 's/...$//'
+	echo -n "M/"
+	hostinfo | awk 'FNR == 8 {print($4)}' | sed 's/...$//' | tr -d '\n'
 	echo -n "G"
 elif [[ ! -z "$max_ram" ]] ; then
 	echo -n "$cur_ram$max_ram"
@@ -16,8 +16,8 @@ fi
 
 # // SWAP // print 'Size' from /proc/swaps
 if [[ "$sys" = "Darwin" ]] ; then
-  echo -ne " ${PURPLE}swap${NC} ~ "
-  sysctl vm.swapusage | awk '{print($7)}'
+	echo -ne " ${PURPLE}swap${NC} ~ "
+	sysctl vm.swapusage | awk '{print($7)}'
 elif [[ "$swap_count" = "2" ]] ; then
 	let "swap1_mb = $swap1_kb / 1024"
 	echo -ne " \e \e \e \e ${PURPLE}swap${NC} ~ "


### PR DESCRIPTION
Here's some work to get the ram and Swap showing a little more reasonably on the MacOS side.

![image](https://user-images.githubusercontent.com/25014799/144302324-bc872c3b-eeab-420c-ab3f-18b71a8e5c7a.png)

Let me know what you think.

Hostname and username are showing properly but are hidden for privacy.

It's also worth mentioning that in regards to Swap on MacOS, it dynamically generates swap files when it absolutely has to, and generates them in 1GB blocks. On MacOS this is a completely automatic process, and non-adjustable by the user. So while we could read out the total number of swap files, it may not be of any practical use to the user, as they will always be 1GB's in size, after which another one will be made by the OS as needed.