### PR TITLE
small issues in README:

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,7 +1,7 @@
 ## Contributing:
 Fork this repository, then clone the desired branch from your fork. In this case we'll be doing the **alpha** branch which is generally the latest build.
 
-&ensp;**#** `git clone -b alpha --single-branch https://github.com/<user>/sysfetch alpha_sysfetch.sh`
+&ensp;**#** `git clone -b alpha --single-branch https://github.com/<user>/sysfetch alpha_sysfetch`
 
 Stage and commit your changes with a relevant message and link to issue # if fix, like:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<h1>fetch.sh alpha</h1>
+<h1>sysfetch alpha</h1>
 <img src="https://github.com/wick3dr0se/fetch.sh/blob/alpha/screen.png"></img>
 
 <img src="https://img.shields.io/badge/Shell_Script-121011?style=for-the-badge&logo=gnu-bash&logoColor=white"></img>
@@ -25,6 +25,11 @@ Stage and commit your changes with a relevant message and link to issue # if fix
 Push your changes and then create a pull request to merge from your branch to this repositorys alpha branch
 
 &ensp;**#** `git push`
+
+#### Communication Channels:
+Join us on discord: https://discord.gg/TstuWvDzXr
+
+Or open an [Issue](https://github.com/wick3dr0se/sysfetch/issues), we're always happy to have more feedback or ideas.
 
 --------------
 
@@ -64,8 +69,10 @@ If installed via makefile:
 --------------
 
 ## Testing:
-For individual scripts that need further testing or are possible implementations
+For individual scripts that need further testing or are possible implementations. Generally most things tested in this branch will be new scripts that are located in the components folder.
 
 &ensp;**#** `git clone -b gamma --single-branch https://github.com/<user>/sysfetch gamma_sysfetch`
 
-Repeat commands from above, however in gamma branch feel free to add your own scripts that could be merged into the alpha branch after testing on atleast two operating systems. Test commands and communicate with us on Discord
+Repeat the commands from [Contributing](#Contributing:) above, however in gamma branch feel free to add your own scripts that could be merged into the alpha branch after testing on at least two operating systems. (Different linuxes or VM's are fine.)
+
+Test commands and output and communicate with us on Discord if you need assistance, or are unsure of something.


### PR DESCRIPTION
fixed small issues in README.md and Contributing, that weren't working with Github Markdown. or just eliminating extra .sh's from the old name.

README.md will still need to be altered when moving to master to remove some of the alpha verbiange, but we're cutting down the bulk of the changes here.